### PR TITLE
Feature/Add MoorDyn capability

### DIFF
--- a/FAST2MATLAB/FAST2Matlab.m
+++ b/FAST2MATLAB/FAST2Matlab.m
@@ -1,4 +1,4 @@
-function DataOut = FAST2Matlab(FST_file,hdrLines,DataOut)
+function DataOut = Fast2Matlab(FST_file,hdrLines,DataOut)
 %% Fast2Matlab
 % DataOut = Fast2Matlab(FST_file,hdrLines,DataOut)
 % Function for reading FAST input files in to a MATLAB struct.

--- a/FAST2MATLAB/FAST2Matlab.m
+++ b/FAST2MATLAB/FAST2Matlab.m
@@ -102,7 +102,7 @@ while true %loop until discovering Outlist or end of file, than break
         break
     end
     
-        % Check to see if the value is Outlist
+        % Check to see if the value is Outlist or OUTPUTS (for MoorDyn)
 
     %if ~isempty(strfind(upper(line),upper('OutList'))) 
     if ~isempty(strfind( upper(line), upper('OutList') )) || contains(upper(line),upper('OUTPUTS'))

--- a/FAST2MATLAB/FAST2Matlab.m
+++ b/FAST2MATLAB/FAST2Matlab.m
@@ -105,18 +105,18 @@ while true %loop until discovering Outlist or end of file, than break
         % Check to see if the value is Outlist
 
     %if ~isempty(strfind(upper(line),upper('OutList'))) 
-    if ~isempty(strfind( upper(line), upper('OutList') )) 
+    if ~isempty(strfind( upper(line), upper('OutList') )) || contains(upper(line),upper('OUTPUTS'))
         % 6/23/2016: linearization inputs contain "OutList" in the
         % comments, so we need to make sure this is either the first (value) or
         % second (label) word of the line.
         [value, ~, ~, nextindex] = sscanf(line,'%s', 1); 
-        if strcmpi(value,'OutList')
+        if strcmpi(value,'OutList') || strcmpi(value,'OUTPUTS')
             [DataOut.OutList DataOut.OutListComments] = ParseFASTOutList(fid);
             break; %bjj: we could continue now if we wanted to assume OutList wasn't the end of the file...
         else
             % try the second
             [value] = sscanf(line(nextindex+1:end),'%s', 1); 
-            if strcmpi(value,'OutList')
+            if strcmpi(value,'OutList') || strcmpi(value,'OUTPUTS')
                 [DataOut.OutList DataOut.OutListComments] = ParseFASTOutList(fid);
                 break; %bjj: we could continue now if we wanted to assume OutList wasn't the end of the file...
             end

--- a/FAST2MATLAB/FAST2Matlab.m
+++ b/FAST2MATLAB/FAST2Matlab.m
@@ -1,4 +1,4 @@
-function DataOut = Fast2Matlab(FST_file,hdrLines,DataOut)
+function DataOut = FAST2Matlab(FST_file,hdrLines,DataOut)
 %% Fast2Matlab
 % DataOut = Fast2Matlab(FST_file,hdrLines,DataOut)
 % Function for reading FAST input files in to a MATLAB struct.
@@ -202,6 +202,20 @@ while true %loop until discovering Outlist or end of file, than break
             line = fgetl(fid);  % the next line is the header, and it may have comments
             [DataOut.profile] = ParseFASTNumTable(line, fid, NumUSRz, 2 );
             continue; %let's continue reading the file
+            
+        elseif strcmpi(value,'"Name"') %we've reached the MoorDyn line types table (and we think it's a string value so it's in quotes)
+            NTypes = GetFASTPar(DataOut,'NTypes');  %get number of LineTypes
+            [DataOut.LineTypes, DataOut.LineTypesHdr] = ParseFASTFmtTable( line, fid, NTypes, true ); %parse the MoorDyn line types table
+            continue;   
+        elseif strcmpi(value,'"Node"') %we've reached the MoorDyn connection properties table (and we think it's a string value so it's in quotes)
+            NConnects = GetFASTPar(DataOut,'NConnects'); %get number of connections (incl. anchors and fairleads)
+            [DataOut.ConProp, DataOut.ConPropHdr] = ParseFASTFmtTable( line, fid, NConnects, true ); %parse the MoorDyn connection properties table
+            continue;   
+        elseif strcmpi(value,'"Line"') %we've reached the MoorDyn line properties table (and we think it's a string value so it's in quotes)
+            NLines = GetFASTPar(DataOut,'NLines'); %get number of line objects  
+            [DataOut.LineProp, DataOut.LinePropHdr] = ParseFASTFmtTable( line, fid, NLines, true ); %parse the MoorDyn line properties table
+            continue;               
+            
         else         
             
             if NextIsMatrix > 0

--- a/MATLAB2FAST/Matlab2FAST.m
+++ b/MATLAB2FAST/Matlab2FAST.m
@@ -235,6 +235,49 @@ while true
             
         elseif strcmpi(label,'NOPRINT') || strcmpi(label,'PRINT')
             continue;  % this comes from AeroDyn BldNodes table                                    
+            
+        elseif strcmpi(label,'NTypes') %we've reached MoorDyn parameter NTypes, so we save its value to be able to skip the table content from the template file when writing the new file
+            NTypes = value;        
+        elseif strcmpi(value,'"Name"') %we've reached the MoorDyn line types table (and we think it's a string value so it's in quotes)
+            if ~isfield(FastPar,'LineTypes')
+                disp( 'WARNING: MoorDyn line types table not found in the FAST data structure.' );
+                printTable = true;
+            else
+                WriteFASTTable(line, fidIN, fidOUT, FastPar.LineTypes, FastPar.LineTypesHdr, newline, 1); %write the MoorDyn line types table 
+                for k = 1:NTypes
+                    fgets(fidIN); %skip the table content from the template file, i.e. prevent it from being written in the new file
+                end                
+                continue; %let's continue reading the template file            
+            end   
+        elseif strcmpi(label,'NConnects') %we've reached MoorDyn parameter NConnects, so we save its value to be able to skip the table content from the template file when writing the new file
+            NConnects = value;
+        elseif strcmpi(value,'"Node"') %we've reached the MoorDyn connection properties table (and we think it's a string value so it's in quotes)
+            if ~isfield(FastPar,'ConProp')
+                disp( 'WARNING: MoorDyn connection properties table not found in the FAST data structure.' );
+                printTable = true;
+            else
+                IntegerCols = {'Node'};
+                WriteFASTTable(line, fidIN, fidOUT, FastPar.ConProp, FastPar.ConPropHdr, newline, 1, IntegerCols); %write the MoorDyn connection properties table
+                for k = 1:NConnects
+                    fgets(fidIN); %skip the table content from the template file, i.e. prevent it from being written in the new file
+                end
+                continue; %let's continue reading the template file            
+            end   
+        elseif strcmpi(label,'NLines') %we've reached MoorDyn parameter NLines, so we save its value to be able to skip the table content from the template file when writing the new file
+            NLines = value;               
+        elseif strcmpi(value,'"Line"') %we've reached the MoorDyn line properties table (and we think it's a string value so it's in quotes)
+            if ~isfield(FastPar,'LineProp')
+                disp( 'WARNING: MoorDyn line properties table not found in the FAST data structure.' );
+                printTable = true;
+            else
+                IntegerCols = {'Line','NumSegs','NodeAnch','NodeFair'};
+                WriteFASTTable(line, fidIN, fidOUT, FastPar.LineProp, FastPar.LinePropHdr, newline, 1, IntegerCols); %write the MoorDyn line properties table
+                for k = 1:NLines
+                    fgets(fidIN); %skip the table content from the template file, i.e. prevent it from being written in the new file
+                end                
+                continue; %let's continue reading the template file            
+            end               
+            
         else
 
             line = GetLineToWrite( line, FastPar, label, TemplateFile, value );

--- a/MATLAB2FAST/Matlab2FAST.m
+++ b/MATLAB2FAST/Matlab2FAST.m
@@ -421,8 +421,18 @@ function WriteFASTTable( HdrLine, fidIN, fidOUT, Table, Headers, newline, NumUni
         return
     end
     
-    colFmtR='%11.7E  ';
-    colFmtI='%9i      ';
+    if strcmpi(TemplateHeaders{1}, 'Name') || strcmpi(TemplateHeaders{1}, 'Node') || strcmpi(TemplateHeaders{1}, 'Line')
+        % We are dealing with a MoorDyn input file, so let's adjust the
+        % format specifier to get a nice readable table.
+        colFmtR='%9.3f ';
+        colFmtI='%- 7i';
+        colFmtS='%-6s ';
+    else
+        colFmtR='%11.7E  ';
+        colFmtI='%9i      ';
+        colFmtS='%s ';
+    end
+    
     if nargin < 8
         IntegerCols={};
     end
@@ -470,7 +480,7 @@ function WriteFASTTable( HdrLine, fidIN, fidOUT, Table, Headers, newline, NumUni
                         fmt = colFmtR;
                     end
                 else                    
-                    fmt = '%s ';
+                    fmt = colFmtS;
                 end
                 fprintf(fidOUT, fmt, Table{i,j} );
             end

--- a/MATLAB2FAST/Matlab2FAST.m
+++ b/MATLAB2FAST/Matlab2FAST.m
@@ -58,7 +58,7 @@ printTableComments = 0;
 NextMatrix = '';
 isInteger = false;
 
-%loop through the template up until OUTLIST or end of file
+%loop through the template up until OUTLIST, OUTPUTS or end of file
 while true
     
     line = fgets(fidIN); %get the next line from the template
@@ -74,19 +74,19 @@ while true
         HaveNewLineChar = true;
     end
     
-    if contains(upper(line),upper('OutList'))        
+    if contains(upper(line),upper('OutList')) || contains(upper(line),upper('OUTPUTS'))
         % 6/23/2016: linearization inputs contain "OutList" in the
         % comments, so we need to make sure this is either the first (value) or
         % second (label) word of the line.
         [value2, ~, ~, nextindex] = sscanf(line,'%s', 1); 
-        if strcmpi(value2,'OutList')
+        if strcmpi(value2,'OutList') || strcmpi(value2,'OUTPUTS')
             ContainsOutList = true;
             fprintf(fidOUT,'%s',line); %if we've found OutList, write the line and break 
             break; %bjj: we could continue now if we wanted to assume OutList wasn't the end of the file...
         else
             % try the second
             [value2] = sscanf(line(nextindex+1:end),'%s', 1); 
-            if strcmpi(value2,'OutList')
+            if strcmpi(value2,'OutList') || strcmpi(value2,'OUTPUTS')
                 ContainsOutList = true;
                 fprintf(fidOUT,'%s',line); %if we've found OutList, write the line and break 
                 break; %bjj: we could continue now if we wanted to assume OutList wasn't the end of the file...


### PR DESCRIPTION
Hallo,

I realized that the matlab-toolbox, especially Fast2Matlab and Matlab2Fast, could not properly handle MoorDyn input files. Thus, I did some copy and paste and adjustments within the mentioned functions and added the missing capability.

I thought that it may help other users in future and thus request to include it in the NREL's master repo.
If you have any questions or reservations regarding the proposed changes, please let me know.

Best regards,
Paul Schünemann