### PR TITLE
Fix error message in `runCommands`

### DIFF
--- a/Utilities/runCommands.m
+++ b/Utilities/runCommands.m
@@ -33,9 +33,9 @@ cd(oldFolder);
 
 
 % --- Check
-if any(status);
+if any(status)
    I=find(status);
    disp('The following simulations failed');
-   disp(sCmd(I));
+   disp(commands{I});
    error('%d/%d simulations failed',length(I),length(commands))
 end

--- a/Utilities/runCommands.m
+++ b/Utilities/runCommands.m
@@ -36,6 +36,6 @@ cd(oldFolder);
 if any(status)
    I=find(status);
    disp('The following simulations failed');
-   disp(commands{I});
+   fprintf('%s\n',commands{I});
    error('%d/%d simulations failed',length(I),length(commands))
 end


### PR DESCRIPTION
Message was displaying _n_ characters from the last run command instead of the _n_ failed commands.