### PR TITLE
MBC: fix issue when a module has both 1st- and 2nd-order states

### DIFF
--- a/ConvertFASTversions/TemplateFiles/AeroDyn15_Primary.dat
+++ b/ConvertFASTversions/TemplateFiles/AeroDyn15_Primary.dat
@@ -5,8 +5,8 @@ Description line that will be printed in the output file and written to the scre
  default            DTAero             - Time interval for aerodynamic calculations {or "default"} (s)
        1            WakeMod            - Type of wake/induction model (switch) {0=none, 1=BEMT, 2=DBEMT, 3=OLAF} [WakeMod cannot be 2 or 3 when linearizing]
        1            AFAeroMod          - Type of blade airfoil aerodynamics model (switch) {1=steady model, 2=Beddoes-Leishman unsteady model} [AFAeroMod must be 1 when linearizing]
-       0            TwrPotent          - Type tower influence on wind based on potential flow around the tower (switch) {0=none, 1=baseline potential flow, 2=potential flow with Bak correction}
-   False            TwrShadow          - Calculate tower influence on wind based on downstream tower shadow? (flag)
+       0            TwrPotent          - Type of tower influence on wind based on potential flow around the tower (switch) {0=none, 1=baseline potential flow, 2=potential flow with Bak correction}
+       0            TwrShadow          - Type of tower influence on wind based on downstream tower shadow (switch) {0=none, 1=Powles model, 2=Eames model}
    False            TwrAero            - Calculate tower aerodynamic loads? (flag)
    False            FrozenWake         - Assume frozen wake during linearization? (flag) [used only when WakeMod=1 and when linearizing]
     True            CavitCheck         - Perform cavitation check? (flag) [AFAeroMod must be 1 when CavitCheck=true]
@@ -51,15 +51,15 @@ Description line that will be printed in the output file and written to the scre
 "AeroDyn_Blade.dat" ADBlFile(1)        - Name of file containing distributed aerodynamic properties for Blade #1 (-)
 "AeroDyn_Blade.dat" ADBlFile(2)        - Name of file containing distributed aerodynamic properties for Blade #2 (-) [unused if NumBl < 2]
 "AeroDyn_Blade.dat" ADBlFile(3)        - Name of file containing distributed aerodynamic properties for Blade #3 (-) [unused if NumBl < 3]
-======  Tower Influence and Aerodynamics ============================================================= [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
-     5               NumTwrNds         - Number of tower nodes used in the analysis  (-) [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
-TwrElev        TwrDiam        TwrCd
-(m)              (m)           (-)
- 0.0            6.0            0.0
-20.0            5.5            0.0
-40.0            5.0            0.0
-60.0            4.5            0.0
-80.0            4.0            0.0
+======  Tower Influence and Aerodynamics ============================================================= [used only when TwrPotent/=0, TwrShadow/=0, or TwrAero=True]
+          5   NumTwrNds         - Number of tower nodes used in the analysis  (-) [used only when TwrPotent/=0, TwrShadow/=0, or TwrAero=True]
+TwrElev        TwrDiam        TwrCd          TwrTI           ! [TwrTI used only with TwrShadow=2]
+(m)              (m)           (-)            (-)
+ 0.0            6.0            0.0            0.01
+20.0            5.5            0.0            0.01
+40.0            5.0            0.0            0.01
+60.0            4.5            0.0            0.01
+80.0            4.0            0.0            0.01
 ======  Outputs  ====================================================================================
  True              SumPrint            - Generate a summary file listing input options and interpolated properties to "<rootname>.AD.sum"?  (flag)
     4              NBlOuts             - Number of blade node outputs [0 - 9] (-)

--- a/ConvertFASTversions/TemplateFiles/AirfoilInfo_v1.01.x.dat
+++ b/ConvertFASTversions/TemplateFiles/AirfoilInfo_v1.01.x.dat
@@ -1,4 +1,4 @@
-! ------------ AirfoilInfo v1.01.x Input File ----------------------------------
+! ------------ AirfoilInfo Input File -----------------------------------------
 ! Description of the Airfoil file here
 ! note that this file uses Marshall Buhl's new input file processing; start all comment lines with !
 !

--- a/MBC/Source/fx_getMats.m
+++ b/MBC/Source/fx_getMats.m
@@ -250,8 +250,9 @@ function [StateOrderingIndx] = getStateOrderingIndx(matData)
     for i=1:matData.NumStates
         
         modName = strtok(matData.DescStates{i}); % name of the module whose states we are looking at
+        ModOrd  = matData.StateDerivOrder(i);
 
-        if ~strcmp(lastModName,modName)
+        if ~strcmp(lastModName,modName) || lastModOrd ~= ModOrd
             
             % this is the start of a new set of DOFs, so we'll set the
             % indices for the last matrix
@@ -267,7 +268,7 @@ function [StateOrderingIndx] = getStateOrderingIndx(matData)
                 sum_nDOFs1 = sum_nDOFs1 + mod_nDOFs;
             end
             
-            % reset for a new module
+            % reset for a new module (or new 1st-order states in the same module)
             mod_nDOFs = 0;
             
             indx_start = i; % start of this module


### PR DESCRIPTION
- updates the template AD input files
- fixes logic in `getStateOrderingIndx`: previous logic assumed each module contained only 2nd-order or only 1st-order states. Now it allows combination of both, though the second order states and their derivatives must be stored together (no 1st order states between them).