### PR TITLE
Fix label matching in GetLineToWrite to avoid false matches in filenames

### DIFF
--- a/MATLAB2FAST/Matlab2FAST.m
+++ b/MATLAB2FAST/Matlab2FAST.m
@@ -373,6 +373,15 @@ function [line] = GetLineToWrite( line, FastPar, label, TemplateFile, value )
         writeVal = getWriteVal( FastPar.Val{indx2} );     
 
         idx = strfind( line, label ); %let's just take the line starting where the label is first listed            
+
+        % Use regex with word boundaries to find the label as an independent field, avoiding false matches inside quoted filenames
+        % If no match is found, keep the original idx from strfind as fallback.
+        regex_pattern = ['\<' regexptranslate('escape', label) '\>'];
+        regex_idx = regexp(line, regex_pattern, 'once');
+        if ~isempty(regex_idx)
+            idx = regex_idx;
+        end
+
         line = [writeVal '   ' line(idx(1):end)];            
 
     else


### PR DESCRIPTION
**Description:**

Use regex with \<...\> word boundaries instead of simple strfind to locate parameter labels as independent fields. This prevents incorrect matching when a label string appears inside a quoted filename.

If the regex pattern fails to match, falls back to the original strfind result.

**Example:**

Before (incorrect matching):
  Template line:
    "WindTurbine_InflowFile.dat" InflowFile  - Name of file containing...

  strfind matches "InflowFile" inside the filename first, resulting in:
    "WindTurbine_InflowFile.dat"    InflowFile.dat" InflowFile  - Name of file...

After (correct matching):
  regex \<...\> matches only the standalone "InflowFile" label, resulting in:
    "WindTurbine_InflowFile.dat"    InflowFile  - Name of file containing...